### PR TITLE
Add supported archtecture info

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - test
 
 jobs:
   # 各テストのジョブは以下の表に従って作成しています。

--- a/src/dinst/arch.d
+++ b/src/dinst/arch.d
@@ -1,0 +1,72 @@
+module dinst.arch;
+
+version (X86)
+{
+	///
+	enum bool isX86 = true;
+	///
+	enum bool isX86_64 = false;
+	///
+	enum bool isAArch64 = false;
+}
+else version (X86_64)
+{
+	///
+	enum bool isX86 = false;
+	///
+	enum bool isX86_64 = true;
+	///
+	enum bool isAArch64 = false;
+}
+else version (AArch64)
+{
+	///
+	enum bool isX86 = false;
+	///
+	enum bool isX86_64 = false;
+	///
+	enum bool isAArch64 = true;
+}
+else static assert(0, "Unsupported Architecture");
+
+version (Windows)
+{
+	///
+	enum bool isWindows = true;
+	///
+	enum bool isLinux = false;
+	///
+	enum bool isPosix = false;
+	///
+	enum bool isMacos = false;
+}
+else version (linux)
+{
+	///
+	enum bool isWindows = false;
+	///
+	enum bool isLinux = true;
+	///
+	enum bool isPosix = true;
+	///
+	enum bool isMacos = false;
+}
+else version (OSX)
+{
+	///
+	enum bool isWindows = false;
+	///
+	enum bool isLinux = false;
+	///
+	enum bool isPosix = true;
+	///
+	enum bool isMacos = true;
+}
+else static assert(0, "Unsupported OS");
+
+///
+enum bool isSupported = 0
+	|| (isWindows && isX86)
+	|| (isWindows && isX86_64)
+	|| (isLinux && isX86)
+	|| (isLinux && isX86_64);

--- a/src/dinst/package.d
+++ b/src/dinst/package.d
@@ -1,3 +1,4 @@
 module dinst;
 
+public import dinst.arch;
 public import dinst.dinst;

--- a/tests/case001/src/bar.d
+++ b/tests/case001/src/bar.d
@@ -10,6 +10,8 @@ int bar(int a) @safe
 @safe unittest
 {
 	import dinst;
+	if (!setupHooks!foo)
+		return;
 	auto foo = setupHook!foo();
 	assert(bar(1) == 2);
 	foo.hook(a => 10);


### PR DESCRIPTION
Add a mechanism to pass unit tests when an architecture is not supported.
Within the unit test, describe it as follows:

```
unittest{
	if (!imported!"dinst".setupHooks!foo)
		return;
}
```